### PR TITLE
fix: changeset setup

### DIFF
--- a/.github/workflows/publish-mcp.yaml
+++ b/.github/workflows/publish-mcp.yaml
@@ -44,7 +44,7 @@ jobs:
           commit: "chore: version mcp"
           title: "chore: version mcp"
           version: npm run version
-          publish: npm run publish
+          publish: npm run release
           cwd: ./mcp
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-typescript.yaml
+++ b/.github/workflows/publish-typescript.yaml
@@ -44,7 +44,7 @@ jobs:
           commit: "chore: version typescript packages"
           title: "chore: version typescript packages"
           version: npm run version
-          publish: npm run publish
+          publish: npm run release
           cwd: ./typescript
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -24,8 +24,8 @@
     "build": "rslib build",
     "build:watch": "rslib build --watch",
     "changeset": "changeset",
-    "prepublish": "npm run build",
-    "publish": "changeset publish",
+    "prerelease": "npm run build",
+    "release": "changeset publish",
     "version": "changeset version",
     "test": "echo \"Error: no test specified\" && exit 0"
   },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -12,8 +12,8 @@
     "lint": "biome check",
     "lint:fix": "biome check --write",
     "changeset": "changeset",
-    "prepublish": "npm run build",
-    "publish": "changeset publish",
+    "prerelease": "npm run build",
+    "release": "changeset publish",
     "version": "changeset version",
     "postversion": "ts-node ./.changeset/bump-version.ts",
     "test": "echo \"Error: no test specified\" && exit 0"


### PR DESCRIPTION
Seems like we can't use `publish` as the script name for changeset publishing.
