### PR TITLE
fix(typescript): query parameters

### DIFF
--- a/typescript/.changeset/weak-icons-add.md
+++ b/typescript/.changeset/weak-icons-add.md
@@ -1,0 +1,5 @@
+---
+"@sumup/agent-toolkit": patch
+---
+
+Fixed query parameters handling for tools and updated path parameters to use camelCase instead of snake_case.

--- a/typescript/src/common/checkouts/parameters.ts
+++ b/typescript/src/common/checkouts/parameters.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const getPaymentMethodsParameters = z.object({
-  merchant_code: z.string().describe(`The SumUp merchant code.`),
+  merchantCode: z.string().describe(`The SumUp merchant code.`),
   amount: z
     .number()
     .describe(
@@ -105,7 +105,7 @@ export const createCheckoutParameters = z
   .describe(`Details of the payment checkout.`);
 
 export const listCheckoutsParameters = z.object({
-  checkout_reference: z
+  checkoutReference: z
     .string()
     .describe(
       `Filters the list of checkout resources by the unique ID of the checkout.`,

--- a/typescript/src/common/checkouts/tools.ts
+++ b/typescript/src/common/checkouts/tools.ts
@@ -17,10 +17,10 @@ export const getPaymentMethods: Tool = {
   parameters: getPaymentMethodsParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof getPaymentMethodsParameters>,
+    { merchantCode, ...args }: z.infer<typeof getPaymentMethodsParameters>,
   ) => {
     const res = await sumup.checkouts.listAvailablePaymentMethods(
-      merchant_code,
+      merchantCode,
       args,
     );
     return JSON.stringify(res);

--- a/typescript/src/common/customers/parameters.ts
+++ b/typescript/src/common/customers/parameters.ts
@@ -42,7 +42,7 @@ export const createCustomerParameters = z.object({
 });
 
 export const getCustomerParameters = z.object({
-  customer_id: z.string().describe(`Unique ID of the saved customer resource.`),
+  customerId: z.string().describe(`Unique ID of the saved customer resource.`),
 });
 
 export const updateCustomerParameters = z.object({
@@ -83,15 +83,15 @@ export const updateCustomerParameters = z.object({
     })
     .describe(`Personal details for the customer.`)
     .optional(),
-  customer_id: z.string().describe(`Unique ID of the saved customer resource.`),
+  customerId: z.string().describe(`Unique ID of the saved customer resource.`),
 });
 
 export const listPaymentInstrumentsParameters = z.object({
-  customer_id: z.string().describe(`Unique ID of the saved customer resource.`),
+  customerId: z.string().describe(`Unique ID of the saved customer resource.`),
 });
 
 export const deactivatePaymentInstrumentParameters = z.object({
-  customer_id: z.string().describe(`Unique ID of the saved customer resource.`),
+  customerId: z.string().describe(`Unique ID of the saved customer resource.`),
   token: z
     .string()
     .describe(

--- a/typescript/src/common/customers/tools.ts
+++ b/typescript/src/common/customers/tools.ts
@@ -29,9 +29,9 @@ export const getCustomer: Tool = {
   parameters: getCustomerParameters,
   callback: async (
     sumup: SumUp,
-    { customer_id, ...args }: z.infer<typeof getCustomerParameters>,
+    { customerId, ...args }: z.infer<typeof getCustomerParameters>,
   ) => {
-    const res = await sumup.customers.get(customer_id, args);
+    const res = await sumup.customers.get(customerId, args);
     return JSON.stringify(res);
   },
 };
@@ -45,9 +45,9 @@ The request only overwrites the parameters included in the request, all other pa
   parameters: updateCustomerParameters,
   callback: async (
     sumup: SumUp,
-    { customer_id, ...args }: z.infer<typeof updateCustomerParameters>,
+    { customerId, ...args }: z.infer<typeof updateCustomerParameters>,
   ) => {
-    const res = await sumup.customers.update(customer_id, args);
+    const res = await sumup.customers.update(customerId, args);
     return JSON.stringify(res);
   },
 };
@@ -58,9 +58,9 @@ export const listPaymentInstruments: Tool = {
   parameters: listPaymentInstrumentsParameters,
   callback: async (
     sumup: SumUp,
-    { customer_id, ...args }: z.infer<typeof listPaymentInstrumentsParameters>,
+    { customerId, ...args }: z.infer<typeof listPaymentInstrumentsParameters>,
   ) => {
-    const res = await sumup.customers.listPaymentInstruments(customer_id, args);
+    const res = await sumup.customers.listPaymentInstruments(customerId, args);
     return JSON.stringify(res);
   },
 };
@@ -72,13 +72,13 @@ export const deactivatePaymentInstrument: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      customer_id,
+      customerId,
       token,
       ...args
     }: z.infer<typeof deactivatePaymentInstrumentParameters>,
   ) => {
     const res = await sumup.customers.deactivatePaymentInstrument(
-      customer_id,
+      customerId,
       token,
       args,
     );

--- a/typescript/src/common/members/parameters.ts
+++ b/typescript/src/common/members/parameters.ts
@@ -24,7 +24,7 @@ export const listMerchantMembersParameters = z.object({
     .array(z.string())
     .describe(`Filter the returned members by role.`)
     .optional(),
-  merchant_code: z.string().describe(`Merchant code.`),
+  merchantCode: z.string().describe(`Merchant code.`),
 });
 
 export const createMerchantMemberParameters = z.object({
@@ -68,12 +68,12 @@ export const createMerchantMemberParameters = z.object({
     .object({})
     .describe(`Object attributes that modifiable only by SumUp applications.`)
     .optional(),
-  merchant_code: z.string().describe(`Merchant code.`),
+  merchantCode: z.string().describe(`Merchant code.`),
 });
 
 export const getMerchantMemberParameters = z.object({
-  merchant_code: z.string().describe(`Merchant code.`),
-  member_id: z.string().describe(`The ID of the member to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  memberId: z.string().describe(`The ID of the member to retrieve.`),
 });
 
 export const updateMerchantMemberParameters = z.object({
@@ -101,11 +101,11 @@ export const updateMerchantMemberParameters = z.object({
     })
     .describe(`Allows you to update user data of managed users.`)
     .optional(),
-  merchant_code: z.string().describe(`Merchant code.`),
-  member_id: z.string().describe(`The ID of the member to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  memberId: z.string().describe(`The ID of the member to retrieve.`),
 });
 
 export const deleteMerchantMemberParameters = z.object({
-  merchant_code: z.string().describe(`Merchant code.`),
-  member_id: z.string().describe(`The ID of the member to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  memberId: z.string().describe(`The ID of the member to retrieve.`),
 });

--- a/typescript/src/common/members/tools.ts
+++ b/typescript/src/common/members/tools.ts
@@ -16,9 +16,9 @@ export const listMerchantMembers: Tool = {
   parameters: listMerchantMembersParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listMerchantMembersParameters>,
+    { merchantCode, ...args }: z.infer<typeof listMerchantMembersParameters>,
   ) => {
-    const res = await sumup.members.list(merchant_code, args);
+    const res = await sumup.members.list(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -29,9 +29,9 @@ export const createMerchantMember: Tool = {
   parameters: createMerchantMemberParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof createMerchantMemberParameters>,
+    { merchantCode, ...args }: z.infer<typeof createMerchantMemberParameters>,
   ) => {
-    const res = await sumup.members.create(merchant_code, args);
+    const res = await sumup.members.create(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -43,12 +43,12 @@ export const getMerchantMember: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      member_id,
+      merchantCode,
+      memberId,
       ...args
     }: z.infer<typeof getMerchantMemberParameters>,
   ) => {
-    const res = await sumup.members.get(merchant_code, member_id, args);
+    const res = await sumup.members.get(merchantCode, memberId, args);
     return JSON.stringify(res);
   },
 };
@@ -60,12 +60,12 @@ export const updateMerchantMember: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      member_id,
+      merchantCode,
+      memberId,
       ...args
     }: z.infer<typeof updateMerchantMemberParameters>,
   ) => {
-    const res = await sumup.members.update(merchant_code, member_id, args);
+    const res = await sumup.members.update(merchantCode, memberId, args);
     return JSON.stringify(res);
   },
 };
@@ -77,12 +77,12 @@ export const deleteMerchantMember: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      member_id,
+      merchantCode,
+      memberId,
       ...args
     }: z.infer<typeof deleteMerchantMemberParameters>,
   ) => {
-    const res = await sumup.members.delete(merchant_code, member_id, args);
+    const res = await sumup.members.delete(merchantCode, memberId, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/memberships/parameters.ts
+++ b/typescript/src/common/memberships/parameters.ts
@@ -15,7 +15,7 @@ export const listMembershipsParameters = z.object({
     .enum(["merchant"])
     .describe(`Filter memberships by resource kind.`)
     .optional(),
-  "resource.attributes.sandbox": z
+  resourceAttributesSandbox: z
     .boolean()
     .describe(
       `Filter memberships by the sandbox status of the resource the membership is in.`,

--- a/typescript/src/common/merchant/parameters.ts
+++ b/typescript/src/common/merchant/parameters.ts
@@ -24,7 +24,7 @@ export const getMerchantProfileParameters = z.object({});
 export const getDoingBusinessAsParameters = z.object({});
 
 export const listBankAccountsV11Parameters = z.object({
-  merchant_code: z.string(),
+  merchantCode: z.string(),
   primary: z
     .boolean()
     .describe(

--- a/typescript/src/common/merchant/tools.ts
+++ b/typescript/src/common/merchant/tools.ts
@@ -70,9 +70,9 @@ export const listBankAccountsV11: Tool = {
   parameters: listBankAccountsV11Parameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listBankAccountsV11Parameters>,
+    { merchantCode, ...args }: z.infer<typeof listBankAccountsV11Parameters>,
   ) => {
-    const res = await sumup.merchant.listBankAccounts(merchant_code, args);
+    const res = await sumup.merchant.listBankAccounts(merchantCode, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/payouts/parameters.ts
+++ b/typescript/src/common/payouts/parameters.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
 export const listPayoutsV1Parameters = z.object({
-  merchant_code: z.string(),
-  start_date: z
+  merchantCode: z.string(),
+  startDate: z
     .string()
     .describe(
       `Start date (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     ),
-  end_date: z
+  endDate: z
     .string()
     .describe(
       `End date (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
@@ -18,12 +18,12 @@ export const listPayoutsV1Parameters = z.object({
 });
 
 export const listPayoutsParameters = z.object({
-  start_date: z
+  startDate: z
     .string()
     .describe(
       `Start date (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     ),
-  end_date: z
+  endDate: z
     .string()
     .describe(
       `End date (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,

--- a/typescript/src/common/payouts/tools.ts
+++ b/typescript/src/common/payouts/tools.ts
@@ -10,9 +10,9 @@ export const listPayoutsV1: Tool = {
   parameters: listPayoutsV1Parameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listPayoutsV1Parameters>,
+    { merchantCode, ...args }: z.infer<typeof listPayoutsV1Parameters>,
   ) => {
-    const res = await sumup.payouts.list(merchant_code, args);
+    const res = await sumup.payouts.list(merchantCode, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/readers/parameters.ts
+++ b/typescript/src/common/readers/parameters.ts
@@ -79,20 +79,20 @@ It is key-value object that can be associated with the transaction.
 It is an optional field that allow for integrators to track the source of the transaction.
 `)
       .optional(),
-    merchant_code: z.string(),
+    merchantCode: z.string(),
     id: z.string().describe(`The unique identifier of the reader.
 `),
   })
   .describe(`Reader Checkout`);
 
 export const createReaderTerminateParameters = z.object({
-  merchant_code: z.string(),
+  merchantCode: z.string(),
   id: z.string().describe(`The unique identifier of the reader.
 `),
 });
 
 export const listReadersParameters = z.object({
-  merchant_code: z
+  merchantCode: z
     .string()
     .describe(`Unique identifier of the merchant account.`),
 });
@@ -113,20 +113,20 @@ export const createReaderParameters = z.object({
     .object({})
     .describe(`Set of user-defined key-value pairs attached to the object.`)
     .optional(),
-  merchant_code: z
+  merchantCode: z
     .string()
     .describe(`Unique identifier of the merchant account.`),
 });
 
 export const getReaderParameters = z.object({
-  merchant_code: z
+  merchantCode: z
     .string()
     .describe(`Unique identifier of the merchant account.`),
   id: z.string().describe(`The unique identifier of the reader.`),
 });
 
 export const deleteReaderParameters = z.object({
-  merchant_code: z
+  merchantCode: z
     .string()
     .describe(`Unique identifier of the merchant account.`),
   id: z.string().describe(`The unique identifier of the reader.`),
@@ -143,7 +143,7 @@ export const updateReaderParameters = z.object({
     .object({})
     .describe(`Set of user-defined key-value pairs attached to the object.`)
     .optional(),
-  merchant_code: z
+  merchantCode: z
     .string()
     .describe(`Unique identifier of the merchant account.`),
   id: z.string().describe(`The unique identifier of the reader.`),

--- a/typescript/src/common/readers/tools.ts
+++ b/typescript/src/common/readers/tools.ts
@@ -29,12 +29,12 @@ There are some caveats when using this endpoint:
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
+      merchantCode,
       id,
       ...args
     }: z.infer<typeof createReaderCheckoutParameters>,
   ) => {
-    const res = await sumup.readers.createCheckout(merchant_code, id, args);
+    const res = await sumup.readers.createCheckout(merchantCode, id, args);
     return JSON.stringify(res);
   },
 };
@@ -61,12 +61,12 @@ If a transaction is successfully terminated and \`return_url\` was provided on C
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
+      merchantCode,
       id,
       ...args
     }: z.infer<typeof createReaderTerminateParameters>,
   ) => {
-    const res = await sumup.readers.terminateCheckout(merchant_code, id, args);
+    const res = await sumup.readers.terminateCheckout(merchantCode, id, args);
     return JSON.stringify(res);
   },
 };
@@ -77,9 +77,9 @@ export const listReaders: Tool = {
   parameters: listReadersParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listReadersParameters>,
+    { merchantCode, ...args }: z.infer<typeof listReadersParameters>,
   ) => {
-    const res = await sumup.readers.list(merchant_code, args);
+    const res = await sumup.readers.list(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -90,9 +90,9 @@ export const createReader: Tool = {
   parameters: createReaderParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof createReaderParameters>,
+    { merchantCode, ...args }: z.infer<typeof createReaderParameters>,
   ) => {
-    const res = await sumup.readers.create(merchant_code, args);
+    const res = await sumup.readers.create(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -103,9 +103,9 @@ export const getReader: Tool = {
   parameters: getReaderParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, id, ...args }: z.infer<typeof getReaderParameters>,
+    { merchantCode, id, ...args }: z.infer<typeof getReaderParameters>,
   ) => {
-    const res = await sumup.readers.get(merchant_code, id, args);
+    const res = await sumup.readers.get(merchantCode, id, args);
     return JSON.stringify(res);
   },
 };
@@ -116,9 +116,9 @@ export const deleteReader: Tool = {
   parameters: deleteReaderParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, id, ...args }: z.infer<typeof deleteReaderParameters>,
+    { merchantCode, id, ...args }: z.infer<typeof deleteReaderParameters>,
   ) => {
-    const res = await sumup.readers.deleteReader(merchant_code, id, args);
+    const res = await sumup.readers.deleteReader(merchantCode, id, args);
     return JSON.stringify(res);
   },
 };
@@ -129,9 +129,9 @@ export const updateReader: Tool = {
   parameters: updateReaderParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, id, ...args }: z.infer<typeof updateReaderParameters>,
+    { merchantCode, id, ...args }: z.infer<typeof updateReaderParameters>,
   ) => {
-    const res = await sumup.readers.update(merchant_code, id, args);
+    const res = await sumup.readers.update(merchantCode, id, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/receipts/parameters.ts
+++ b/typescript/src/common/receipts/parameters.ts
@@ -7,7 +7,7 @@ export const getReceiptParameters = z.object({
       `SumUp unique transaction ID or transaction code, e.g. TS7HDYLSKD.`,
     ),
   mid: z.string().describe(`Merchant code.`),
-  tx_event_id: z
+  txEventId: z
     .number()
     .int()
     .describe(`The ID of the transaction event (refund).`)

--- a/typescript/src/common/roles/parameters.ts
+++ b/typescript/src/common/roles/parameters.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const listMerchantRolesParameters = z.object({
-  merchant_code: z.string().describe(`Merchant code.`),
+  merchantCode: z.string().describe(`Merchant code.`),
 });
 
 export const createMerchantRoleParameters = z.object({
@@ -17,17 +17,17 @@ export const createMerchantRoleParameters = z.object({
     .string()
     .describe(`User-defined description of the role.`)
     .optional(),
-  merchant_code: z.string().describe(`Merchant code.`),
+  merchantCode: z.string().describe(`Merchant code.`),
 });
 
 export const getMerchantRoleParameters = z.object({
-  merchant_code: z.string().describe(`Merchant code.`),
-  role_id: z.string().describe(`The ID of the role to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  roleId: z.string().describe(`The ID of the role to retrieve.`),
 });
 
 export const deleteMerchantRoleParameters = z.object({
-  merchant_code: z.string().describe(`Merchant code.`),
-  role_id: z.string().describe(`The ID of the role to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  roleId: z.string().describe(`The ID of the role to retrieve.`),
 });
 
 export const updateMerchantRoleParameters = z.object({
@@ -37,6 +37,6 @@ export const updateMerchantRoleParameters = z.object({
     .string()
     .describe(`User-defined description of the role.`)
     .optional(),
-  merchant_code: z.string().describe(`Merchant code.`),
-  role_id: z.string().describe(`The ID of the role to retrieve.`),
+  merchantCode: z.string().describe(`Merchant code.`),
+  roleId: z.string().describe(`The ID of the role to retrieve.`),
 });

--- a/typescript/src/common/roles/tools.ts
+++ b/typescript/src/common/roles/tools.ts
@@ -16,9 +16,9 @@ export const listMerchantRoles: Tool = {
   parameters: listMerchantRolesParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listMerchantRolesParameters>,
+    { merchantCode, ...args }: z.infer<typeof listMerchantRolesParameters>,
   ) => {
-    const res = await sumup.roles.list(merchant_code, args);
+    const res = await sumup.roles.list(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -29,9 +29,9 @@ export const createMerchantRole: Tool = {
   parameters: createMerchantRoleParameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof createMerchantRoleParameters>,
+    { merchantCode, ...args }: z.infer<typeof createMerchantRoleParameters>,
   ) => {
-    const res = await sumup.roles.create(merchant_code, args);
+    const res = await sumup.roles.create(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -43,12 +43,12 @@ export const getMerchantRole: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      role_id,
+      merchantCode,
+      roleId,
       ...args
     }: z.infer<typeof getMerchantRoleParameters>,
   ) => {
-    const res = await sumup.roles.get(merchant_code, role_id, args);
+    const res = await sumup.roles.get(merchantCode, roleId, args);
     return JSON.stringify(res);
   },
 };
@@ -60,12 +60,12 @@ export const deleteMerchantRole: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      role_id,
+      merchantCode,
+      roleId,
       ...args
     }: z.infer<typeof deleteMerchantRoleParameters>,
   ) => {
-    const res = await sumup.roles.delete(merchant_code, role_id, args);
+    const res = await sumup.roles.delete(merchantCode, roleId, args);
     return JSON.stringify(res);
   },
 };
@@ -77,12 +77,12 @@ export const updateMerchantRole: Tool = {
   callback: async (
     sumup: SumUp,
     {
-      merchant_code,
-      role_id,
+      merchantCode,
+      roleId,
       ...args
     }: z.infer<typeof updateMerchantRoleParameters>,
   ) => {
-    const res = await sumup.roles.update(merchant_code, role_id, args);
+    const res = await sumup.roles.update(merchantCode, roleId, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/subaccounts/parameters.ts
+++ b/typescript/src/common/subaccounts/parameters.ts
@@ -9,7 +9,7 @@ Current implementation allow querying only over the email address.
 All operators whos email address contains the query string are returned.
 `)
     .optional(),
-  include_primary: z
+  includePrimary: z
     .boolean()
     .describe(
       `If true the list of operators will include also the primary user.`,
@@ -32,7 +32,7 @@ export const createSubAccountParameters = z.object({
 });
 
 export const compatGetOperatorParameters = z.object({
-  operator_id: z.number().int(),
+  operatorId: z.number().int(),
 });
 
 export const updateSubAccountParameters = z.object({
@@ -48,9 +48,9 @@ export const updateSubAccountParameters = z.object({
       refund_transactions: z.boolean(),
     })
     .optional(),
-  operator_id: z.number().int(),
+  operatorId: z.number().int(),
 });
 
 export const deactivateSubAccountParameters = z.object({
-  operator_id: z.number().int(),
+  operatorId: z.number().int(),
 });

--- a/typescript/src/common/subaccounts/tools.ts
+++ b/typescript/src/common/subaccounts/tools.ts
@@ -42,9 +42,9 @@ export const compatGetOperator: Tool = {
   parameters: compatGetOperatorParameters,
   callback: async (
     sumup: SumUp,
-    { operator_id, ...args }: z.infer<typeof compatGetOperatorParameters>,
+    { operatorId, ...args }: z.infer<typeof compatGetOperatorParameters>,
   ) => {
-    const res = await sumup.subaccounts.compatGetOperator(operator_id, args);
+    const res = await sumup.subaccounts.compatGetOperator(operatorId, args);
     return JSON.stringify(res);
   },
 };
@@ -55,9 +55,9 @@ export const updateSubAccount: Tool = {
   parameters: updateSubAccountParameters,
   callback: async (
     sumup: SumUp,
-    { operator_id, ...args }: z.infer<typeof updateSubAccountParameters>,
+    { operatorId, ...args }: z.infer<typeof updateSubAccountParameters>,
   ) => {
-    const res = await sumup.subaccounts.updateSubAccount(operator_id, args);
+    const res = await sumup.subaccounts.updateSubAccount(operatorId, args);
     return JSON.stringify(res);
   },
 };
@@ -68,9 +68,9 @@ export const deactivateSubAccount: Tool = {
   parameters: deactivateSubAccountParameters,
   callback: async (
     sumup: SumUp,
-    { operator_id, ...args }: z.infer<typeof deactivateSubAccountParameters>,
+    { operatorId, ...args }: z.infer<typeof deactivateSubAccountParameters>,
   ) => {
-    const res = await sumup.subaccounts.deactivateSubAccount(operator_id, args);
+    const res = await sumup.subaccounts.deactivateSubAccount(operatorId, args);
     return JSON.stringify(res);
   },
 };

--- a/typescript/src/common/transactions/parameters.ts
+++ b/typescript/src/common/transactions/parameters.ts
@@ -8,25 +8,25 @@ export const refundTransactionParameters = z
         `Amount to be refunded. Eligible amount can't exceed the amount of the transaction and varies based on country and currency. If you do not specify a value, the system performs a full refund of the transaction.`,
       )
       .optional(),
-    txn_id: z.string().describe(`Unique ID of the transaction.`),
+    txnId: z.string().describe(`Unique ID of the transaction.`),
   })
   .describe(`Optional amount for partial refunds of transactions.`);
 
 export const getTransactionV2_1Parameters = z.object({
-  merchant_code: z.string(),
+  merchantCode: z.string(),
   id: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified transaction ID (the \`id\` parameter in the transaction resource).`,
     )
     .optional(),
-  internal_id: z
+  internalId: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified internal transaction ID (the \`internal_id\` parameter in the transaction resource).`,
     )
     .optional(),
-  transaction_code: z
+  transactionCode: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified transaction code.`,
@@ -41,13 +41,13 @@ export const getTransactionParameters = z.object({
       `Retrieves the transaction resource with the specified transaction ID (the \`id\` parameter in the transaction resource).`,
     )
     .optional(),
-  internal_id: z
+  internalId: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified internal transaction ID (the \`internal_id\` parameter in the transaction resource).`,
     )
     .optional(),
-  transaction_code: z
+  transactionCode: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified transaction code.`,
@@ -56,8 +56,8 @@ export const getTransactionParameters = z.object({
 });
 
 export const listTransactionsV2_1Parameters = z.object({
-  merchant_code: z.string(),
-  transaction_code: z
+  merchantCode: z.string(),
+  transactionCode: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified transaction code.`,
@@ -88,7 +88,7 @@ export const listTransactionsV2_1Parameters = z.object({
       `Filters the returned results by the specified list of final statuses of the transactions.`,
     )
     .optional(),
-  payment_types: z
+  paymentTypes: z
     .array(
       z.enum(["CASH", "POS", "ECOM", "BALANCE", "MOTO", "BOLETO", "UNKNOWN"]),
     )
@@ -102,31 +102,31 @@ export const listTransactionsV2_1Parameters = z.object({
       `Filters the returned results by the specified list of transaction types.`,
     )
     .optional(),
-  changes_since: z
+  changesSince: z
     .string()
     .describe(
       `Filters the results by the latest modification time of resources and returns only transactions that are modified *at or after* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  newest_time: z
+  newestTime: z
     .string()
     .describe(
       `Filters the results by the creation time of resources and returns only transactions that are created *before* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  newest_ref: z
+  newestRef: z
     .string()
     .describe(
       `Filters the results by the reference ID of transaction events and returns only transactions with events whose IDs are *smaller* than the specified value. This parameters supersedes the \`newest_time\` parameter (if both are provided in the request).`,
     )
     .optional(),
-  oldest_time: z
+  oldestTime: z
     .string()
     .describe(
       `Filters the results by the creation time of resources and returns only transactions that are created *at or after* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  oldest_ref: z
+  oldestRef: z
     .string()
     .describe(
       `Filters the results by the reference ID of transaction events and returns only transactions with events whose IDs are *greater* than the specified value. This parameters supersedes the \`oldest_time\` parameter (if both are provided in the request).`,
@@ -135,7 +135,7 @@ export const listTransactionsV2_1Parameters = z.object({
 });
 
 export const listTransactionsParameters = z.object({
-  transaction_code: z
+  transactionCode: z
     .string()
     .describe(
       `Retrieves the transaction resource with the specified transaction code.`,
@@ -166,7 +166,7 @@ export const listTransactionsParameters = z.object({
       `Filters the returned results by the specified list of final statuses of the transactions.`,
     )
     .optional(),
-  payment_types: z
+  paymentTypes: z
     .array(
       z.enum(["CASH", "POS", "ECOM", "BALANCE", "MOTO", "BOLETO", "UNKNOWN"]),
     )
@@ -180,31 +180,31 @@ export const listTransactionsParameters = z.object({
       `Filters the returned results by the specified list of transaction types.`,
     )
     .optional(),
-  changes_since: z
+  changesSince: z
     .string()
     .describe(
       `Filters the results by the latest modification time of resources and returns only transactions that are modified *at or after* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  newest_time: z
+  newestTime: z
     .string()
     .describe(
       `Filters the results by the creation time of resources and returns only transactions that are created *before* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  newest_ref: z
+  newestRef: z
     .string()
     .describe(
       `Filters the results by the reference ID of transaction events and returns only transactions with events whose IDs are *smaller* than the specified value. This parameters supersedes the \`newest_time\` parameter (if both are provided in the request).`,
     )
     .optional(),
-  oldest_time: z
+  oldestTime: z
     .string()
     .describe(
       `Filters the results by the creation time of resources and returns only transactions that are created *at or after* the specified timestamp (in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601) format).`,
     )
     .optional(),
-  oldest_ref: z
+  oldestRef: z
     .string()
     .describe(
       `Filters the results by the reference ID of transaction events and returns only transactions with events whose IDs are *greater* than the specified value. This parameters supersedes the \`oldest_time\` parameter (if both are provided in the request).`,

--- a/typescript/src/common/transactions/tools.ts
+++ b/typescript/src/common/transactions/tools.ts
@@ -16,9 +16,9 @@ export const refundTransaction: Tool = {
   parameters: refundTransactionParameters,
   callback: async (
     sumup: SumUp,
-    { txn_id, ...args }: z.infer<typeof refundTransactionParameters>,
+    { txnId, ...args }: z.infer<typeof refundTransactionParameters>,
   ) => {
-    const res = await sumup.transactions.refund(txn_id, args);
+    const res = await sumup.transactions.refund(txnId, args);
     return JSON.stringify(res);
   },
 };
@@ -36,9 +36,9 @@ export const getTransactionV2_1: Tool = {
   parameters: getTransactionV2_1Parameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof getTransactionV2_1Parameters>,
+    { merchantCode, ...args }: z.infer<typeof getTransactionV2_1Parameters>,
   ) => {
-    const res = await sumup.transactions.get(merchant_code, args);
+    const res = await sumup.transactions.get(merchantCode, args);
     return JSON.stringify(res);
   },
 };
@@ -69,9 +69,9 @@ export const listTransactionsV2_1: Tool = {
   parameters: listTransactionsV2_1Parameters,
   callback: async (
     sumup: SumUp,
-    { merchant_code, ...args }: z.infer<typeof listTransactionsV2_1Parameters>,
+    { merchantCode, ...args }: z.infer<typeof listTransactionsV2_1Parameters>,
   ) => {
-    const res = await sumup.transactions.list(merchant_code, args);
+    const res = await sumup.transactions.list(merchantCode, args);
     return JSON.stringify(res);
   },
 };


### PR DESCRIPTION
There was a mismatch in casing of parameters between generated code and the SumUp Node.js SDK. Now fixed. We also switch path parameters to use camel case instead of snake case.
