### PR TITLE
fix(typescript): remove unsupported parameters

### DIFF
--- a/typescript/.changeset/sour-geckos-hang.md
+++ b/typescript/.changeset/sour-geckos-hang.md
@@ -1,0 +1,5 @@
+---
+"@sumup/agent-toolkit": patch
+---
+
+Removed unsupported parameters. `.` and `[]` are not supported by MCP and would require re-mapping between MCP objects and data passed to SumUp SDK.

--- a/typescript/src/common/memberships/parameters.ts
+++ b/typescript/src/common/memberships/parameters.ts
@@ -15,10 +15,4 @@ export const listMembershipsParameters = z.object({
     .enum(["merchant"])
     .describe(`Filter memberships by resource kind.`)
     .optional(),
-  resourceAttributesSandbox: z
-    .boolean()
-    .describe(
-      `Filter memberships by the sandbox status of the resource the membership is in.`,
-    )
-    .optional(),
 });

--- a/typescript/src/common/merchant/parameters.ts
+++ b/typescript/src/common/merchant/parameters.ts
@@ -1,21 +1,6 @@
 import { z } from "zod";
 
-export const getAccountParameters = z.object({
-  "include[]": z
-    .array(
-      z.enum([
-        "settings",
-        "doing_business_as",
-        "bank_accounts",
-        "app_settings",
-        "country_details",
-      ]),
-    )
-    .describe(
-      `A list of additional information you want to receive for the user. By default only personal and merchant profile information will be returned.`,
-    )
-    .optional(),
-});
+export const getAccountParameters = z.object({});
 
 export const getPersonalProfileParameters = z.object({});
 


### PR DESCRIPTION
MCP can't handle parameters with `[]` or `.`. Remove such parameters for now as supporting them would require re-mapping between parameter objects and what we pass to SumUp SDK which significantly increases the complexity of a code in the Typescript Agent Toolkit SDK.
