### PR TITLE
chore(cd): don't run release please on release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: >-
+      !startsWith(github.event.head_commit.message, 'release: ')
     steps:
       - name: Release Please
         uses: google-github-actions/release-please-action@v4


### PR DESCRIPTION
Prevent release-please from running again when a release PR created by release-please is merged.

The release job now skips release merge commits whose head commit message starts with `release: `.
