### PR TITLE
chore(cd): don't run release please on release

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,12 +13,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: >-
-      !startsWith(github.event.head_commit.message, 'release: ')
     steps:
       - name: Release Please
         uses: google-github-actions/release-please-action@v4
         with:
+          skip-github-pull-request: "${{ startsWith(github.event.head_commit.message, 'release: ') }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json


### PR DESCRIPTION
Prevent release-please from running again when a release PR created by release-please is merged.

The release-please action now uses `skip-github-pull-request` when the head commit message starts with `release: `.