### PR TITLE
fix(toolkit): require approval for mutating tools

### DIFF
--- a/codegen/src/generator.ts
+++ b/codegen/src/generator.ts
@@ -460,6 +460,7 @@ async function writeToolsFile(
       `  annotations: {`,
       `    title: ${toTemplateLiteral(operation.summary)},`,
       `    readOnly: ${operation.method === OpenAPIV3.HttpMethods.GET},`,
+      `    requiresApproval: ${operation.method !== OpenAPIV3.HttpMethods.GET},`,
       `    destructive: ${operation.method === OpenAPIV3.HttpMethods.DELETE},`,
       `    idempotent: ${operation.method === OpenAPIV3.HttpMethods.PUT},`,
       `    oauthScopes: [${operation.oauthScopes.map((scope) => JSON.stringify(scope)).join(", ")}],`,

--- a/typescript/src/ai/toolkit.test.ts
+++ b/typescript/src/ai/toolkit.test.ts
@@ -1,3 +1,8 @@
+jest.mock("ai", () => ({
+  tool: (options: unknown) => options,
+  zodSchema: (schema: unknown) => schema,
+}));
+
 import SumUpAgentToolkit from "./toolkit";
 
 describe("SumUpAgentToolkit approval policy", () => {
@@ -27,7 +32,7 @@ describe("SumUpAgentToolkit approval policy", () => {
             {
               toolCallId: "tool-call-id",
               messages: [],
-              experimental_context: undefined,
+              context: undefined,
             },
           ),
         ),

--- a/typescript/src/ai/toolkit.test.ts
+++ b/typescript/src/ai/toolkit.test.ts
@@ -1,0 +1,37 @@
+import SumUpAgentToolkit from "./toolkit";
+
+describe("SumUpAgentToolkit approval policy", () => {
+  it("requires approval for mutating tools by default", () => {
+    const toolkit = new SumUpAgentToolkit({ apiKey: "test-api-key" });
+    const tools = toolkit.getTools();
+
+    expect(tools.refund_transaction?.needsApproval).toBe(true);
+    expect(tools.create_reader_checkout?.needsApproval).toBe(true);
+    expect(tools.get_transaction_v2_1?.needsApproval).toBe(false);
+  });
+
+  it("allows callers to override the approval policy", async () => {
+    const toolkit = new SumUpAgentToolkit({
+      apiKey: "test-api-key",
+      approvalPolicy: (tool) => tool.name === "get_transaction_v2_1",
+    });
+    const needsApproval =
+      toolkit.getTools().get_transaction_v2_1?.needsApproval;
+
+    expect(typeof needsApproval).toBe("function");
+    if (typeof needsApproval === "function") {
+      expect(
+        await Promise.resolve(
+          needsApproval(
+            { merchantCode: "MCODE" },
+            {
+              toolCallId: "tool-call-id",
+              messages: [],
+              experimental_context: undefined,
+            },
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+});

--- a/typescript/src/ai/toolkit.ts
+++ b/typescript/src/ai/toolkit.ts
@@ -3,6 +3,7 @@ import SumUp from "@sumup/sdk";
 import { type ToolSet, tool, zodSchema } from "ai";
 import type z from "zod";
 import { registerTools } from "../common";
+import type { ApprovalPolicy } from "../common/types";
 
 class SumUpAgentToolkit {
   private _sumup: SumUp;
@@ -12,9 +13,11 @@ class SumUpAgentToolkit {
   constructor({
     apiKey,
     host,
+    approvalPolicy,
   }: {
     apiKey: string;
     host?: string;
+    approvalPolicy?: ApprovalPolicy;
   }) {
     this._sumup = new SumUp({ apiKey, host });
     this.tools = {};
@@ -29,7 +32,9 @@ class SumUpAgentToolkit {
         description: t.description,
         inputSchema: zodSchema(t.parameters),
         outputSchema: zodSchema(t.result),
-        needsApproval: !!t.annotations?.destructive,
+        needsApproval: approvalPolicy
+          ? (input) => approvalPolicy(t, input)
+          : !!t.annotations?.requiresApproval,
         execute: async (input: z.infer<typeof t.parameters>) => {
           const res = await t.callback(this._sumup, input);
           return t.result.parse(res);

--- a/typescript/src/common/checkouts/tools.ts
+++ b/typescript/src/common/checkouts/tools.ts
@@ -36,6 +36,7 @@ session object that your frontend should pass to Apple's JavaScript API.`,
   annotations: {
     title: `Create an Apple Pay session`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: true,
     oauthScopes: [],
@@ -62,6 +63,7 @@ Follow by processing a checkout to charge the provided payment instrument.`,
   annotations: {
     title: `Create a checkout`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payments"],
@@ -83,6 +85,7 @@ export const deactivateCheckout: Tool<
   annotations: {
     title: `Deactivate a checkout`,
     readOnly: false,
+    requiresApproval: true,
     destructive: true,
     idempotent: false,
     oauthScopes: ["payments"],
@@ -104,6 +107,7 @@ export const getCheckout: Tool<
   annotations: {
     title: `Retrieve a checkout`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payments"],
@@ -128,6 +132,7 @@ export const getPaymentMethods: Tool<
   annotations: {
     title: `Get available payment methods`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -149,6 +154,7 @@ export const listCheckouts: Tool<
   annotations: {
     title: `List checkouts`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payments"],

--- a/typescript/src/common/customers/tools.ts
+++ b/typescript/src/common/customers/tools.ts
@@ -29,6 +29,7 @@ export const createCustomer: Tool<
   annotations: {
     title: `Create a customer`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payment_instruments"],
@@ -54,6 +55,7 @@ export const deactivatePaymentInstrument: Tool<
   annotations: {
     title: `Deactivate a payment instrument`,
     readOnly: false,
+    requiresApproval: true,
     destructive: true,
     idempotent: false,
     oauthScopes: ["payment_instruments"],
@@ -75,6 +77,7 @@ export const getCustomer: Tool<
   annotations: {
     title: `Retrieve a customer`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payment_instruments"],
@@ -96,6 +99,7 @@ export const listPaymentInstruments: Tool<
   annotations: {
     title: `List payment instruments`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payment_instruments"],
@@ -119,6 +123,7 @@ The request only overwrites the parameters included in the request, all other pa
   annotations: {
     title: `Update a customer`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: true,
     oauthScopes: ["payment_instruments"],

--- a/typescript/src/common/members/tools.ts
+++ b/typescript/src/common/members/tools.ts
@@ -29,6 +29,7 @@ export const createMerchantMember: Tool<
   annotations: {
     title: `Create a member`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -50,6 +51,7 @@ export const deleteMerchantMember: Tool<
   annotations: {
     title: `Delete a member`,
     readOnly: false,
+    requiresApproval: true,
     destructive: true,
     idempotent: false,
     oauthScopes: [],
@@ -71,6 +73,7 @@ export const getMerchantMember: Tool<
   annotations: {
     title: `Retrieve a member`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -92,6 +95,7 @@ export const listMerchantMembers: Tool<
   annotations: {
     title: `List members`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -113,6 +117,7 @@ export const updateMerchantMember: Tool<
   annotations: {
     title: `Update a member`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: true,
     oauthScopes: [],

--- a/typescript/src/common/memberships/tools.ts
+++ b/typescript/src/common/memberships/tools.ts
@@ -18,6 +18,7 @@ export const listMemberships: Tool<
   annotations: {
     title: `List memberships`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],

--- a/typescript/src/common/merchants/tools.ts
+++ b/typescript/src/common/merchants/tools.ts
@@ -25,6 +25,7 @@ export const getMerchant: Tool<
   annotations: {
     title: `Retrieve a Merchant`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["user.profile", "user.profile_readonly"],
@@ -46,6 +47,7 @@ export const getPerson: Tool<
   annotations: {
     title: `Retrieve a Person`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["user.profile", "user.profile_readonly"],
@@ -67,6 +69,7 @@ export const listPersons: Tool<
   annotations: {
     title: `List Persons`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["user.profile", "user.profile_readonly"],

--- a/typescript/src/common/payouts/tools.ts
+++ b/typescript/src/common/payouts/tools.ts
@@ -24,6 +24,7 @@ Results are sorted by payout date in the requested \`order\`.`,
   annotations: {
     title: `List payouts`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["user.profile", "user.profile_readonly"],

--- a/typescript/src/common/readers/tools.ts
+++ b/typescript/src/common/readers/tools.ts
@@ -35,6 +35,7 @@ export const createReader: Tool<
   annotations: {
     title: `Create a Reader`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.write"],
@@ -66,6 +67,7 @@ There are some caveats when using this endpoint:
   annotations: {
     title: `Create a Reader Checkout`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.write"],
@@ -100,6 +102,7 @@ If a transaction is successfully terminated and \`return_url\` was provided on C
   annotations: {
     title: `Terminate a Reader Checkout`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.write"],
@@ -121,6 +124,7 @@ export const deleteReader: Tool<
   annotations: {
     title: `Delete a reader`,
     readOnly: false,
+    requiresApproval: true,
     destructive: true,
     idempotent: false,
     oauthScopes: ["readers.write"],
@@ -142,6 +146,7 @@ export const getReader: Tool<
   annotations: {
     title: `Retrieve a Reader`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.read"],
@@ -181,6 +186,7 @@ Device Status
   annotations: {
     title: `Get a Reader Status`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.read"],
@@ -202,6 +208,7 @@ export const listReaders: Tool<
   annotations: {
     title: `List Readers`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.read"],
@@ -223,6 +230,7 @@ export const updateReader: Tool<
   annotations: {
     title: `Update a Reader`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["readers.write"],

--- a/typescript/src/common/receipts/tools.ts
+++ b/typescript/src/common/receipts/tools.ts
@@ -18,6 +18,7 @@ export const getReceipt: Tool<
   annotations: {
     title: `Retrieve receipt details`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],

--- a/typescript/src/common/roles/tools.ts
+++ b/typescript/src/common/roles/tools.ts
@@ -29,6 +29,7 @@ export const createMerchantRole: Tool<
   annotations: {
     title: `Create a role`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -50,6 +51,7 @@ export const deleteMerchantRole: Tool<
   annotations: {
     title: `Delete a role`,
     readOnly: false,
+    requiresApproval: true,
     destructive: true,
     idempotent: false,
     oauthScopes: [],
@@ -71,6 +73,7 @@ export const getMerchantRole: Tool<
   annotations: {
     title: `Retrieve a role`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -92,6 +95,7 @@ export const listMerchantRoles: Tool<
   annotations: {
     title: `List roles`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: [],
@@ -113,6 +117,7 @@ export const updateMerchantRole: Tool<
   annotations: {
     title: `Update a role`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: [],

--- a/typescript/src/common/transactions/tools.ts
+++ b/typescript/src/common/transactions/tools.ts
@@ -29,6 +29,7 @@ export const getTransactionV2_1: Tool<
   annotations: {
     title: `Retrieve a transaction`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["transactions.history"],
@@ -50,6 +51,7 @@ export const listTransactionsV2_1: Tool<
   annotations: {
     title: `List transactions`,
     readOnly: true,
+    requiresApproval: false,
     destructive: false,
     idempotent: false,
     oauthScopes: ["transactions.history"],
@@ -71,6 +73,7 @@ export const refundTransaction: Tool<
   annotations: {
     title: `Refund a transaction`,
     readOnly: false,
+    requiresApproval: true,
     destructive: false,
     idempotent: false,
     oauthScopes: ["payments"],

--- a/typescript/src/common/types.ts
+++ b/typescript/src/common/types.ts
@@ -14,7 +14,7 @@ export type Tool<
   annotations?: Annotations;
 };
 
-type Annotations = {
+export type Annotations = {
   /**
    * A human-readable title for the tool.
    */
@@ -25,6 +25,13 @@ type Annotations = {
    * Default: false
    */
   readOnly?: boolean;
+  /**
+   * If true, agent-framework adapters should require human approval before
+   * executing the tool.
+   *
+   * Default: false
+   */
+  requiresApproval?: boolean;
   /**
    * If true, the tool may perform destructive updates to its environment.
    * If false, the tool performs only additive updates.
@@ -48,3 +55,8 @@ type Annotations = {
    */
   oauthScopes?: string[];
 };
+
+export type ApprovalPolicy = (
+  tool: Pick<Tool, "name" | "title" | "annotations">,
+  input: unknown,
+) => boolean | Promise<boolean>;

--- a/typescript/src/openai/toolkit.test.ts
+++ b/typescript/src/openai/toolkit.test.ts
@@ -1,0 +1,40 @@
+import SumUpAgentToolkit from "./toolkit";
+
+describe("SumUpAgentToolkit approval policy", () => {
+  it("requires approval for mutating tools by default", async () => {
+    const tools = new SumUpAgentToolkit({
+      apiKey: "test-api-key",
+    }).getTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+    const requiresApproval = async (name: string) => {
+      const needsApproval = byName.get(name)?.needsApproval;
+      return typeof needsApproval === "function"
+        ? await needsApproval({} as never, {})
+        : needsApproval;
+    };
+
+    await expect(requiresApproval("refund_transaction")).resolves.toBe(true);
+    await expect(requiresApproval("create_reader_checkout")).resolves.toBe(
+      true,
+    );
+    await expect(requiresApproval("get_transaction_v2_1")).resolves.toBe(false);
+  });
+
+  it("allows callers to override the approval policy", async () => {
+    const tools = new SumUpAgentToolkit({
+      apiKey: "test-api-key",
+      approvalPolicy: (tool) => tool.name === "get_transaction_v2_1",
+    }).getTools();
+    const needsApproval = tools.find(
+      (tool) => tool.name === "get_transaction_v2_1",
+    )?.needsApproval;
+
+    expect(typeof needsApproval).toBe("function");
+    if (typeof needsApproval === "function") {
+      await expect(
+        needsApproval({} as never, { merchantCode: "MCODE" }),
+      ).resolves.toBe(true);
+    }
+  });
+});

--- a/typescript/src/openai/toolkit.ts
+++ b/typescript/src/openai/toolkit.ts
@@ -1,6 +1,7 @@
 import { tool } from "@openai/agents";
 import SumUp from "@sumup/sdk";
 import { registerTools } from "../common";
+import type { ApprovalPolicy } from "../common/types";
 
 type AgentFunctionTool = ReturnType<typeof tool>;
 
@@ -12,9 +13,11 @@ class SumUpAgentToolkit {
   constructor({
     apiKey,
     host,
+    approvalPolicy,
   }: {
     apiKey: string;
     host?: string;
+    approvalPolicy?: ApprovalPolicy;
   }) {
     this._sumup = new SumUp({
       apiKey,
@@ -29,7 +32,9 @@ class SumUpAgentToolkit {
           description: t.description,
           strict: true,
           parameters: t.parameters,
-          needsApproval: !!t.annotations?.destructive,
+          needsApproval: approvalPolicy
+            ? async (_runContext, input) => await approvalPolicy(t, input)
+            : !!t.annotations?.requiresApproval,
           execute: async (input) => {
             const res = await t.callback(this._sumup, input);
             return t.result.parse(res);


### PR DESCRIPTION
## What changed

- add generated `requiresApproval` metadata independently from MCP destructive hints
- require approval by default for all non-read operations in the AI SDK and OpenAI Agents adapters
- allow consumers to provide an argument-aware approval policy
- cover refunds, reader checkouts, reads, and custom policies

## Why

The adapters previously mapped approval only from `destructive`, while codegen marks only HTTP DELETE operations as destructive. Financial and other mutating POST/PUT/PATCH tools could therefore execute without a human approval interruption.

## Impact

Mutating tools now pause for approval by default. Consumers can override that decision with `approvalPolicy` when they need a more specific policy.

## Validation

- `npm --prefix typescript test -- --runInBand`
- `npm --prefix typescript run lint:fix`
- `npm --prefix codegen run lint`

`npm --prefix typescript run build` still reports the existing default-branch declaration errors introduced by the current dependency set: AI SDK tool generic arity, `createApplePaySession`, and the transaction refund signature.
