### PR TITLE
perf(mcp): reduce tool catalog context

### DIFF
--- a/typescript/src/mcp/toolkit.test.ts
+++ b/typescript/src/mcp/toolkit.test.ts
@@ -21,6 +21,7 @@ jest.mock("../common", () => {
         result: ReturnType<typeof z.object>;
         annotations?: {
           oauthScopes?: string[];
+          readOnly?: boolean;
         };
         callback: typeof mockToolkitState.callback;
       }) => void,
@@ -35,6 +36,21 @@ jest.mock("../common", () => {
         }),
         annotations: {
           oauthScopes: ["mock.read", "mock.write"],
+          readOnly: true,
+        },
+        callback: async (sumup: SumUp) => mockToolkitState.callback(sumup),
+      });
+      reg({
+        name: "mutating_tool",
+        title: "Mutating tool",
+        description: "Mock mutating tool for catalog filtering tests",
+        parameters: z.object({}),
+        result: z.object({
+          ok: z.boolean(),
+        }),
+        annotations: {
+          oauthScopes: ["mock.write"],
+          readOnly: false,
         },
         callback: async (sumup: SumUp) => mockToolkitState.callback(sumup),
       });
@@ -120,5 +136,66 @@ describe("mcp toolkit auth error handling", () => {
         'bearer error="invalid_token", resource_metadata="https://api.sumup.example/.well-known/oauth-protected-resource"',
       );
     }
+  });
+});
+
+describe("mcp toolkit catalog configuration", () => {
+  const registeredTools = (toolkit: SumUpAgentToolkit) =>
+    Object.keys(
+      // biome-ignore lint/suspicious/noExplicitAny: test inspects internal registration
+      (toolkit as any)._registeredTools,
+    );
+
+  test("omits output schemas by default while retaining result validation", async () => {
+    mockToolkitState.callback = async () => ({ ok: true });
+    const toolkit = new SumUpAgentToolkit({ configuration: {} });
+    const tool =
+      // biome-ignore lint/suspicious/noExplicitAny: test inspects internal registration
+      (toolkit as any)._registeredTools.mock_tool;
+
+    expect(tool.outputSchema).toBeUndefined();
+    await expect(tool.handler({})).resolves.toMatchObject({
+      structuredContent: { ok: true },
+      content: [{ text: '{"ok":true}' }],
+    });
+
+    mockToolkitState.callback = async () =>
+      ({ ok: "invalid" }) as unknown as { ok: boolean };
+    await expect(tool.handler({})).rejects.toThrow();
+  });
+
+  test("can opt in to advertised output schemas", () => {
+    const toolkit = new SumUpAgentToolkit({
+      configuration: {},
+      includeOutputSchemas: true,
+    });
+    const tool =
+      // biome-ignore lint/suspicious/noExplicitAny: test inspects internal registration
+      (toolkit as any)._registeredTools.mock_tool;
+
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  test("supports include and exclude filters", () => {
+    const included = new SumUpAgentToolkit({
+      configuration: {},
+      includeTools: ["mock_tool"],
+    });
+    const excluded = new SumUpAgentToolkit({
+      configuration: {},
+      excludeTools: ["mutating_tool"],
+    });
+
+    expect(registeredTools(included)).toEqual(["mock_tool"]);
+    expect(registeredTools(excluded)).toEqual(["mock_tool"]);
+  });
+
+  test("can expose only read-only tools", () => {
+    const toolkit = new SumUpAgentToolkit({
+      configuration: {},
+      readOnly: true,
+    });
+
+    expect(registeredTools(toolkit)).toEqual(["mock_tool"]);
   });
 });

--- a/typescript/src/mcp/toolkit.ts
+++ b/typescript/src/mcp/toolkit.ts
@@ -21,6 +21,10 @@ export type SumUpAgentToolkitOptions = {
   resource?: string;
   resourceMetadata?: string;
   observability?: ToolObservability;
+  includeTools?: string[];
+  excludeTools?: string[];
+  readOnly?: boolean;
+  includeOutputSchemas?: boolean;
   configuration: ServerOptions;
 };
 
@@ -42,6 +46,10 @@ class SumUpAgentToolkit extends McpServer {
     resource,
     resourceMetadata,
     observability,
+    includeTools,
+    excludeTools = [],
+    readOnly = false,
+    includeOutputSchemas = false,
   }: SumUpAgentToolkitOptions) {
     super(
       {
@@ -102,7 +110,18 @@ class SumUpAgentToolkit extends McpServer {
       },
     );
 
+    const includedToolNames = includeTools ? new Set(includeTools) : undefined;
+    const excludedToolNames = new Set(excludeTools);
+
     registerTools((tool) => {
+      if (
+        (includedToolNames && !includedToolNames.has(tool.name)) ||
+        excludedToolNames.has(tool.name) ||
+        (readOnly && !tool.annotations?.readOnly)
+      ) {
+        return;
+      }
+
       this.registerTool(
         tool.name,
         {
@@ -110,7 +129,9 @@ class SumUpAgentToolkit extends McpServer {
           description: tool.description,
           inputSchema: tool.parameters.shape,
           outputSchema:
-            tool.result instanceof z.ZodObject ? tool.result.shape : undefined,
+            includeOutputSchemas && tool.result instanceof z.ZodObject
+              ? tool.result.shape
+              : undefined,
           annotations: {
             title: tool.annotations?.title,
             readOnlyHint: tool.annotations?.readOnly,
@@ -140,7 +161,7 @@ class SumUpAgentToolkit extends McpServer {
               content: [
                 {
                   type: "text" as const,
-                  text: JSON.stringify(structuredContent, null, 2),
+                  text: JSON.stringify(structuredContent),
                 },
               ],
             };


### PR DESCRIPTION
## What changed

- make MCP output-schema advertisement opt-in
- retain server-side Zod validation for every tool result
- add include, exclude, and read-only catalog filters
- emit compact JSON text alongside structured content

## Why

The default 36-tool catalog was approximately 149 KB, with full output schemas accounting for most of the payload. That context is paid before the model calls a tool, and consumers had no way to narrow the exposed surface.

## Impact

The default MCP catalog is materially smaller. Consumers that need output schemas can set `includeOutputSchemas`, while deployments can constrain tools with `includeTools`, `excludeTools`, or `readOnlyOnly`.

## Validation

- `npm --prefix typescript run lint`
- `npm --prefix typescript test -- --runInBand`

The package build remains blocked by the existing default-branch declaration errors from the current dependency set.
