### PR TITLE
test(toolkit): cover adapter and MCP contracts

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -25,7 +25,7 @@
     "build": "rslib build",
     "build:watch": "rslib build --watch",
     "prepublishOnly": "npm run build",
-    "test": "echo \"Error: no test specified\" && exit 0"
+    "test": "npm run build && node --test test/*.test.mjs"
   },
   "bugs": {
     "url": "https://github.com/sumup/sumup-ai/issues"

--- a/mcp/test/stdio.test.mjs
+++ b/mcp/test/stdio.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import test from "node:test";
+
+test("serves the tool catalog over stdio", { timeout: 15_000 }, async () => {
+  const server = spawn(process.execPath, ["dist/index.mjs"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      SUMUP_API_KEY: "test-api-key",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let stderr = "";
+  server.stderr.setEncoding("utf8");
+  server.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+
+  const pending = new Map();
+  let stdoutBuffer = "";
+  server.stdout.setEncoding("utf8");
+  server.stdout.on("data", (chunk) => {
+    stdoutBuffer += chunk;
+    const lines = stdoutBuffer.split("\n");
+    stdoutBuffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      if (!line) continue;
+      const message = JSON.parse(line);
+      pending.get(message.id)?.(message);
+      pending.delete(message.id);
+    }
+  });
+
+  const request = (message) =>
+    new Promise((resolve, reject) => {
+      pending.set(message.id, resolve);
+      server.stdin.write(`${JSON.stringify(message)}\n`, (error) => {
+        if (error) reject(error);
+      });
+    });
+
+  try {
+    const initialized = await request({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "stdio-test", version: "1.0.0" },
+      },
+    });
+    assert.equal(initialized.result.serverInfo.name, "SumUp");
+
+    server.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" })}\n`,
+    );
+    const listed = await request({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    });
+
+    assert.ok(listed.result.tools.length > 0);
+  } finally {
+    server.kill();
+    await new Promise((resolve) => server.once("close", resolve));
+  }
+
+  assert.match(stderr, /SumUp MCP Server running on stdio/);
+});

--- a/typescript/src/mcp/catalog.test.ts
+++ b/typescript/src/mcp/catalog.test.ts
@@ -1,0 +1,24 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import SumUpAgentToolkit from "./toolkit";
+
+describe("MCP catalog budget", () => {
+  test("keeps tools/list within the agreed context budget", async () => {
+    const server = new SumUpAgentToolkit({ configuration: {} });
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const listed = await client.listTools();
+      expect(listed.tools.length).toBeGreaterThan(0);
+      expect(Buffer.byteLength(JSON.stringify(listed))).toBeLessThan(165_000);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/typescript/src/mcp/transport.test.ts
+++ b/typescript/src/mcp/transport.test.ts
@@ -1,0 +1,73 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type SumUp from "@sumup/sdk";
+
+jest.mock("../common", () => {
+  const actual = jest.requireActual("../common");
+  const { z } = jest.requireActual("zod");
+
+  return {
+    ...actual,
+    registerTools: (
+      reg: (tool: {
+        name: string;
+        title: string;
+        description: string;
+        parameters: ReturnType<typeof z.object>;
+        result: ReturnType<typeof z.object>;
+        callback: (sumup: SumUp, input: { value: string }) => Promise<unknown>;
+      }) => void,
+    ) =>
+      reg({
+        name: "echo_value",
+        title: "Echo value",
+        description: "Returns the supplied value",
+        parameters: z.object({ value: z.string() }),
+        result: z.object({ value: z.string() }),
+        callback: async (_sumup: SumUp, input: { value: string }) => ({
+          value: input.value,
+        }),
+      }),
+  };
+});
+
+import SumUpAgentToolkit from "./toolkit";
+
+describe("MCP transport contract", () => {
+  test("lists and calls tools through the MCP client transport", async () => {
+    const server = new SumUpAgentToolkit({
+      apiKey: "test-api-key",
+      configuration: {},
+    });
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const listed = await client.listTools();
+      expect(listed.tools.map((tool) => tool.name)).toEqual(["echo_value"]);
+
+      await expect(
+        client.callTool({
+          name: "echo_value",
+          arguments: { value: "hello" },
+        }),
+      ).resolves.toMatchObject({
+        structuredContent: { value: "hello" },
+      });
+
+      await expect(
+        client.callTool({
+          name: "echo_value",
+          arguments: { value: 42 },
+        }),
+      ).resolves.toMatchObject({ isError: true });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/typescript/src/toolkit-adapters.test.ts
+++ b/typescript/src/toolkit-adapters.test.ts
@@ -1,0 +1,112 @@
+import type SumUp from "@sumup/sdk";
+
+const mockToolState = {
+  callback: async (_sumup: SumUp, input: { value: string }) => ({
+    value: input.value,
+  }),
+};
+
+jest.mock("./common", () => {
+  const actual = jest.requireActual("./common");
+  const { z } = jest.requireActual("zod");
+
+  return {
+    ...actual,
+    registerTools: (
+      reg: (tool: {
+        name: string;
+        title: string;
+        description: string;
+        parameters: ReturnType<typeof z.object>;
+        result: ReturnType<typeof z.object>;
+        callback: typeof mockToolState.callback;
+      }) => void,
+    ) =>
+      reg({
+        name: "echo_value",
+        title: "Echo value",
+        description: "Returns the supplied value",
+        parameters: z.object({ value: z.string() }),
+        result: z.object({ value: z.string() }),
+        callback: async (sumup: SumUp, input: { value: string }) =>
+          mockToolState.callback(sumup, input),
+      }),
+  };
+});
+
+import AiSdkToolkit from "./ai/toolkit";
+import LangChainToolkit from "./langchain/toolkit";
+import OpenAiToolkit from "./openai/toolkit";
+
+describe("agent framework adapter contracts", () => {
+  beforeEach(() => {
+    mockToolState.callback = async (_sumup, input) => ({ value: input.value });
+  });
+
+  test("AI SDK tools execute callbacks and validate results", async () => {
+    const tool = new AiSdkToolkit({ apiKey: "test-api-key" }).getTools()
+      .echo_value;
+    if (!tool?.execute) throw new Error("AI SDK tool is not executable");
+
+    await expect(
+      tool.execute(
+        { value: "hello" },
+        {
+          toolCallId: "tool-call-id",
+          messages: [],
+          abortSignal: new AbortController().signal,
+        },
+      ),
+    ).resolves.toEqual({ value: "hello" });
+
+    mockToolState.callback = async () =>
+      ({ value: 42 }) as unknown as { value: string };
+    await expect(
+      tool.execute(
+        { value: "hello" },
+        {
+          toolCallId: "tool-call-id",
+          messages: [],
+          abortSignal: new AbortController().signal,
+        },
+      ),
+    ).rejects.toThrow();
+  });
+
+  test("LangChain tools validate inputs and results", async () => {
+    const tool = new LangChainToolkit({
+      apiKey: "test-api-key",
+    }).getTools()[0];
+    if (!tool) throw new Error("LangChain tool was not registered");
+
+    await expect(tool.invoke({ value: "hello" })).resolves.toEqual({
+      value: "hello",
+    });
+    await expect(tool.invoke({ value: 42 })).rejects.toThrow();
+
+    mockToolState.callback = async () =>
+      ({ value: 42 }) as unknown as { value: string };
+    await expect(tool.invoke({ value: "hello" })).rejects.toThrow();
+  });
+
+  test("OpenAI Agents tools execute callbacks and validate results", async () => {
+    const tool = new OpenAiToolkit({
+      apiKey: "test-api-key",
+    })
+      .getTools()
+      .find((candidate) => candidate.name === "echo_value");
+    if (tool?.type !== "function") {
+      throw new Error("OpenAI function tool was not registered");
+    }
+
+    await expect(
+      tool.invoke({} as never, JSON.stringify({ value: "hello" })),
+    ).resolves.toEqual({ value: "hello" });
+
+    mockToolState.callback = async () =>
+      ({ value: 42 }) as unknown as { value: string };
+    await expect(
+      tool.invoke({} as never, JSON.stringify({ value: "hello" })),
+    ).resolves.toEqual(expect.any(String));
+  });
+});

--- a/typescript/src/toolkit-adapters.test.ts
+++ b/typescript/src/toolkit-adapters.test.ts
@@ -6,6 +6,11 @@ const mockToolState = {
   }),
 };
 
+jest.mock("ai", () => ({
+  tool: (options: unknown) => options,
+  zodSchema: (schema: unknown) => schema,
+}));
+
 jest.mock("./common", () => {
   const actual = jest.requireActual("./common");
   const { z } = jest.requireActual("zod");
@@ -55,6 +60,7 @@ describe("agent framework adapter contracts", () => {
           toolCallId: "tool-call-id",
           messages: [],
           abortSignal: new AbortController().signal,
+          context: undefined,
         },
       ),
     ).resolves.toEqual({ value: "hello" });
@@ -68,6 +74,7 @@ describe("agent framework adapter contracts", () => {
           toolCallId: "tool-call-id",
           messages: [],
           abortSignal: new AbortController().signal,
+          context: undefined,
         },
       ),
     ).rejects.toThrow();


### PR DESCRIPTION
## What changed

- add executable contract tests for AI SDK, LangChain, and OpenAI Agents adapters
- drive MCP `tools/list` and `tools/call` over linked in-memory transports
- add a regression budget for the serialized MCP catalog
- replace the standalone MCP package's no-op test with a packaged stdio integration test

## Why

Only authentication and a directly invoked MCP handler were covered. Adapter schema conversion, framework execution, MCP transport behavior, catalog growth, and the published stdio entry point could regress without a failing test.

## Impact

The test suite now checks the public integration seams consumers use, including invalid inputs/results and the built standalone package.

## Validation

- `npm --prefix typescript run lint`
- `npm --prefix typescript test -- --runInBand`
- `npm --prefix mcp run lint:fix`
- `npm --prefix mcp test`
