### PR TITLE
fix(mcp): require Node.js 22

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -24,7 +24,7 @@
         "typescript": "^7.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -38,7 +38,7 @@
     "modelcontextprotocol"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## What changed

- require Node.js 22 or newer in the standalone MCP package
- keep the lockfile root package metadata in sync

## Why

`@sumup/mcp` advertised Node.js 18 support, but its `@sumup/agent-toolkit` dependency requires Node.js 22. Package managers could therefore install an incompatible dependency graph.

## Impact

Consumers receive the correct engine compatibility signal before attempting to start the server.

## Validation

- `npm --prefix mcp run lint`
- `npm pack --dry-run` from `mcp/`
