### PR TITLE
fix(mcp): fail fast on invalid startup

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -10,9 +10,13 @@ function handleError(error: any) {
 }
 
 async function main() {
+  const apiKey = process.env.SUMUP_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error("SUMUP_API_KEY environment variable is required");
+  }
+
   const server = new SumUpAgentToolkit({
-    // biome-ignore lint/style/noNonNullAssertion: it's ok to fail here
-    apiKey: process.env.SUMUP_API_KEY!,
+    apiKey,
     configuration: {},
   });
 
@@ -24,4 +28,5 @@ async function main() {
 
 main().catch((error) => {
   handleError(error);
+  process.exitCode = 1;
 });


### PR DESCRIPTION
## What changed

- validate `SUMUP_API_KEY` before constructing the stdio server
- reject blank values as well as missing values
- set a nonzero process exit status for initialization errors

## Why

The server previously accepted an undefined API key and announced readiness. Authentication then failed only when a tool was called, and initialization errors could still leave a successful process status.

## Impact

MCP clients and process supervisors now receive an immediate, actionable startup failure.

## Validation

- `npm --prefix mcp run lint`
- `npm --prefix mcp run build`
- started the built entry point without `SUMUP_API_KEY` and verified exit status 1 plus the expected error message
