### PR TITLE
build(mcp): use npm ci in the image

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install --frozen-lockfile && npm run build
+RUN npm ci && npm run build
 
 USER user
 


### PR DESCRIPTION
## What changed

- replace `npm install --frozen-lockfile` with `npm ci` in the MCP image build

## Why

npm does not enforce dependency immutability through the `--frozen-lockfile` option. The image build could therefore resolve dependencies differently from `package-lock.json`.

## Impact

Container dependency installation now fails on lockfile drift and installs the exact committed graph.

## Validation

- `npm ci --ignore-scripts` from `mcp/`
- complete `docker build` of the MCP image
