### PR TITLE
fix(mcp): keep OAuth challenges at HTTP boundary

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -22,6 +22,18 @@ npm install @sumup/agent-toolkit
 yarn add @sumup/agent-toolkit
 ```
 
+### Remote MCP authentication
+
+When serving the MCP toolkit over HTTP, validate bearer tokens before MCP tool
+dispatch and attach the validated token to the request's `authInfo`. Missing or
+invalid credentials must produce an HTTP `401` response with a
+`WWW-Authenticate` challenge at the transport boundary, as required by the
+[MCP authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization).
+
+Do not rely on a downstream SumUp API `401` as an OAuth challenge: by that
+point the request is already inside JSON-RPC tool execution and cannot produce
+the HTTP response expected by MCP clients.
+
 ## [LangChain](https://www.langchain.com/)
 
 ```ts

--- a/typescript/src/mcp/toolkit.test.ts
+++ b/typescript/src/mcp/toolkit.test.ts
@@ -1,4 +1,3 @@
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type SumUp from "@sumup/sdk";
 import { APIError } from "@sumup/sdk";
 
@@ -83,24 +82,19 @@ describe("mcp toolkit auth error handling", () => {
     });
   });
 
-  test("maps @sumup/sdk APIError(401) with WWW-Authenticate to McpError", async () => {
+  test("does not encode HTTP authentication challenges as tool errors", async () => {
+    const response = new Response(JSON.stringify({ error: "invalid_token" }), {
+      status: 401,
+      headers: {
+        "www-authenticate": 'Bearer error="invalid_token"',
+      },
+    });
+    const apiError = new APIError(401, { error: "invalid_token" }, response);
     mockToolkitState.callback = async () => {
-      const response = new Response(
-        JSON.stringify({ error: "invalid_token" }),
-        {
-          status: 401,
-          headers: {
-            "www-authenticate": 'Bearer error="invalid_token"',
-          },
-        },
-      );
-
-      throw new APIError(401, { error: "invalid_token" }, response);
+      throw apiError;
     };
 
     const toolkit = new SumUpAgentToolkit({
-      resourceMetadata:
-        "https://api.sumup.example/.well-known/oauth-protected-resource",
       configuration: {},
     });
 
@@ -108,17 +102,6 @@ describe("mcp toolkit auth error handling", () => {
       // biome-ignore lint/suspicious/noExplicitAny: test inspects internal registration
       (toolkit as any)._registeredTools.mock_tool;
 
-    await expect(tool.handler({})).rejects.toBeInstanceOf(McpError);
-
-    try {
-      await tool.handler({});
-    } catch (error) {
-      const mcpError = error as McpError;
-      const data = mcpError.data as { wwwAuthenticate?: string } | undefined;
-      expect(mcpError.code).toBe(ErrorCode.InternalError);
-      expect(data?.wwwAuthenticate).toBe(
-        'bearer error="invalid_token", resource_metadata="https://api.sumup.example/.well-known/oauth-protected-resource"',
-      );
-    }
+    await expect(tool.handler({})).rejects.toBe(apiError);
   });
 });

--- a/typescript/src/mcp/toolkit.ts
+++ b/typescript/src/mcp/toolkit.ts
@@ -1,22 +1,16 @@
 import type { ServerOptions } from "@modelcontextprotocol/sdk/server/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import SumUp, { APIError } from "@sumup/sdk";
+import SumUp from "@sumup/sdk";
 import { z } from "zod";
-import {
-  constructResourceMetadata,
-  parseWWWAuthenticateChallenges,
-  registerTools,
-  stringifyWWWAuthenticateChallenges,
-  TOOL_OAUTH_SCOPES_META_KEY,
-  VERSION,
-} from "../common";
+import { registerTools, TOOL_OAUTH_SCOPES_META_KEY, VERSION } from "../common";
 
 export type SumUpAgentToolkitOptions = {
   apiKey?: string;
   host?: string;
+  /** @deprecated Enforce remote MCP authorization at the HTTP transport boundary. */
   resource?: string;
+  /** @deprecated Enforce remote MCP authorization at the HTTP transport boundary. */
   resourceMetadata?: string;
   configuration: ServerOptions;
 };
@@ -24,7 +18,6 @@ export type SumUpAgentToolkitOptions = {
 class SumUpAgentToolkit extends McpServer {
   private _apiKey?: string;
   private _host?: string;
-  private _resourceMetadata?: string;
 
   /**
    * Builds a SumUp MCP server.
@@ -33,12 +26,7 @@ class SumUpAgentToolkit extends McpServer {
    * leave it unset and rely on the validated bearer token propagated through
    * the MCP request's auth context.
    */
-  constructor({
-    apiKey,
-    host,
-    resource,
-    resourceMetadata,
-  }: SumUpAgentToolkitOptions) {
+  constructor({ apiKey, host }: SumUpAgentToolkitOptions) {
     super(
       {
         name: "SumUp",
@@ -53,8 +41,6 @@ class SumUpAgentToolkit extends McpServer {
       },
     );
 
-    this._resourceMetadata =
-      resourceMetadata ?? constructResourceMetadata(resource);
     this._apiKey = apiKey;
     this._host = host;
 
@@ -123,71 +109,22 @@ class SumUpAgentToolkit extends McpServer {
           args: z.infer<typeof tool.parameters>,
           extra,
         ): Promise<CallToolResult> => {
-          try {
-            const sumup = this.createClient(extra?.authInfo?.token);
-            const result = tool.result.parse(await tool.callback(sumup, args));
-            const structuredContent =
-              typeof result === "object" && result !== null
-                ? (result as Record<string, unknown>)
-                : undefined;
+          const sumup = this.createClient(extra?.authInfo?.token);
+          const result = tool.result.parse(await tool.callback(sumup, args));
+          const structuredContent =
+            typeof result === "object" && result !== null
+              ? (result as Record<string, unknown>)
+              : undefined;
 
-            return {
-              structuredContent,
-              content: [
-                {
-                  type: "text" as const,
-                  text: JSON.stringify(structuredContent, null, 2),
-                },
-              ],
-            };
-          } catch (error) {
-            // Handle OAuth authorization errors
-            if (error instanceof APIError && error.status === 401) {
-              const wwwAuthenticate =
-                error.response.headers.get("www-authenticate");
-
-              if (wwwAuthenticate && this._resourceMetadata) {
-                const challenges =
-                  parseWWWAuthenticateChallenges(wwwAuthenticate);
-                if (
-                  challenges?.some((challenge) => challenge.scheme === "bearer")
-                ) {
-                  const enhancedHeader = stringifyWWWAuthenticateChallenges(
-                    challenges.map((challenge) => {
-                      if (challenge.scheme !== "bearer" || challenge.token68) {
-                        return challenge;
-                      }
-
-                      return {
-                        ...challenge,
-                        parameters: {
-                          ...challenge.parameters,
-                          resource_metadata: this._resourceMetadata,
-                        },
-                      };
-                    }),
-                  );
-
-                  // Throw McpError with www-authenticate header in data
-                  // This follows the MCP error protocol for authorization errors
-                  throw new McpError(
-                    ErrorCode.InternalError,
-                    "Authentication required",
-                    {
-                      wwwAuthenticate: enhancedHeader,
-                    },
-                  );
-                }
-              }
-            }
-
-            // For any other errors, re-throw to let MCP SDK handle them
-            if (error instanceof Error) {
-              throw error;
-            }
-
-            throw new Error(String(error));
-          }
+          return {
+            structuredContent,
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(structuredContent, null, 2),
+              },
+            ],
+          };
         },
       );
     });


### PR DESCRIPTION
## What changed

- remove downstream API `401` conversion into JSON-RPC `InternalError`
- preserve the original SumUp SDK authentication error
- deprecate the ineffective resource metadata constructor options
- document bearer validation, HTTP challenges, and `authInfo` propagation for remote transports

## Why

MCP OAuth discovery requires an HTTP `401` response with a `WWW-Authenticate` header. A tool-level JSON-RPC error carrying a similarly named data property cannot trigger the client authorization flow and incorrectly claimed protocol compliance.

## Impact

The toolkit no longer emits a nonstandard OAuth representation. Remote HTTP deployments have an explicit contract to reject invalid credentials before MCP dispatch and pass validated tokens through request auth context.

## Validation

- `npm --prefix typescript run lint:fix`
- `npm --prefix typescript test -- --runInBand`

Specification reference: https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
