### PR TITLE
feat(toolkit): add tool execution observability

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -22,6 +22,26 @@ npm install @sumup/agent-toolkit
 yarn add @sumup/agent-toolkit
 ```
 
+### Observability
+
+Every adapter accepts optional redaction-safe lifecycle callbacks. Events include
+the tool name, start time, duration, and errors, but never tool arguments or
+results. Callback failures are ignored so telemetry cannot break tool execution.
+
+```ts
+const sumupAgentToolkit = new SumUpAgentToolkit({
+  apiKey: process.env.SUMUP_API_KEY!,
+  observability: {
+    onToolEnd: ({ toolName, durationMs }) => {
+      metrics.histogram("sumup.agent_tool.duration", durationMs, { toolName });
+    },
+    onToolError: ({ toolName, error }) => {
+      logger.error({ toolName, error }, "SumUp agent tool failed");
+    },
+  },
+});
+```
+
 ## [LangChain](https://www.langchain.com/)
 
 ```ts

--- a/typescript/src/ai/toolkit.ts
+++ b/typescript/src/ai/toolkit.ts
@@ -2,7 +2,7 @@ import SumUp from "@sumup/sdk";
 
 import { type ToolSet, tool, zodSchema } from "ai";
 import type z from "zod";
-import { registerTools } from "../common";
+import { executeTool, registerTools, type ToolObservability } from "../common";
 import type { ApprovalPolicy } from "../common/types";
 
 class SumUpAgentToolkit {
@@ -14,10 +14,12 @@ class SumUpAgentToolkit {
     apiKey,
     host,
     approvalPolicy,
+    observability,
   }: {
     apiKey: string;
     host?: string;
     approvalPolicy?: ApprovalPolicy;
+    observability?: ToolObservability;
   }) {
     this._sumup = new SumUp({ apiKey, host });
     this.tools = {};
@@ -36,8 +38,7 @@ class SumUpAgentToolkit {
           ? (input) => approvalPolicy(t, input)
           : !!t.annotations?.requiresApproval,
         execute: async (input: z.infer<typeof t.parameters>) => {
-          const res = await t.callback(this._sumup, input);
-          return t.result.parse(res);
+          return await executeTool(t, this._sumup, input, observability);
         },
       });
     });

--- a/typescript/src/common/execute.test.ts
+++ b/typescript/src/common/execute.test.ts
@@ -1,0 +1,74 @@
+import type SumUp from "@sumup/sdk";
+import { z } from "zod";
+import { executeTool, type ToolObservability } from "./execute";
+import type { Tool } from "./types";
+
+const parameters = z.object({ value: z.string() });
+const result = z.object({ value: z.string() });
+const tool: Tool<typeof parameters, typeof result> = {
+  name: "echo_value",
+  title: "Echo value",
+  description: "Returns the supplied value",
+  parameters,
+  result,
+  callback: async (_sumup, input) => ({ value: input.value }),
+};
+const sumup = {} as SumUp;
+
+describe("executeTool", () => {
+  test("reports successful execution without exposing input or output", async () => {
+    const events: unknown[] = [];
+    const observability: ToolObservability = {
+      onToolStart: (event) => {
+        events.push(event);
+      },
+      onToolEnd: (event) => {
+        events.push(event);
+      },
+    };
+
+    await expect(
+      executeTool(tool, sumup, { value: "sensitive" }, observability),
+    ).resolves.toEqual({ value: "sensitive" });
+    expect(events).toHaveLength(2);
+    expect(events).toEqual([
+      expect.objectContaining({ toolName: "echo_value" }),
+      expect.objectContaining({
+        toolName: "echo_value",
+        durationMs: expect.any(Number),
+      }),
+    ]);
+    expect(JSON.stringify(events)).not.toContain("sensitive");
+  });
+
+  test("reports failures and preserves the original error", async () => {
+    const error = new Error("tool failed");
+    const failingTool = {
+      ...tool,
+      callback: async () => {
+        throw error;
+      },
+    };
+    const onToolError = jest.fn();
+
+    await expect(
+      executeTool(failingTool, sumup, { value: "hello" }, { onToolError }),
+    ).rejects.toBe(error);
+    expect(onToolError).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "echo_value", error }),
+    );
+  });
+
+  test("does not let observability failures affect tool execution", async () => {
+    const onToolStart = async () => {
+      throw new Error("telemetry unavailable");
+    };
+    const onToolEnd = async () => {
+      throw new Error("telemetry unavailable");
+    };
+
+    await expect(
+      executeTool(tool, sumup, { value: "hello" }, { onToolStart, onToolEnd }),
+    ).resolves.toEqual({ value: "hello" });
+  });
+});

--- a/typescript/src/common/execute.ts
+++ b/typescript/src/common/execute.ts
@@ -1,0 +1,63 @@
+import type SumUp from "@sumup/sdk";
+import type { z } from "zod";
+import type { Tool } from "./types";
+
+export type ToolExecutionStarted = {
+  toolName: string;
+  startedAt: number;
+};
+
+export type ToolExecutionCompleted = ToolExecutionStarted & {
+  durationMs: number;
+};
+
+export type ToolExecutionFailed = ToolExecutionCompleted & {
+  error: unknown;
+};
+
+export type ToolObservability = {
+  onToolStart?: (event: ToolExecutionStarted) => void | Promise<void>;
+  onToolEnd?: (event: ToolExecutionCompleted) => void | Promise<void>;
+  onToolError?: (event: ToolExecutionFailed) => void | Promise<void>;
+};
+
+const notify = async <Event>(
+  callback: ((event: Event) => void | Promise<void>) | undefined,
+  event: Event,
+) => {
+  try {
+    await callback?.(event);
+  } catch {
+    // Observability must never change tool execution behavior.
+  }
+};
+
+export const executeTool = async <
+  Args extends z.ZodObject<z.ZodRawShape>,
+  Result extends z.ZodTypeAny,
+>(
+  tool: Tool<Args, Result>,
+  sumup: SumUp,
+  input: z.infer<Args>,
+  observability?: ToolObservability,
+): Promise<z.infer<Result>> => {
+  const startedAt = Date.now();
+  const started = { toolName: tool.name, startedAt };
+  await notify(observability?.onToolStart, started);
+
+  try {
+    const result = tool.result.parse(await tool.callback(sumup, input));
+    await notify(observability?.onToolEnd, {
+      ...started,
+      durationMs: Date.now() - startedAt,
+    });
+    return result;
+  } catch (error) {
+    await notify(observability?.onToolError, {
+      ...started,
+      durationMs: Date.now() - startedAt,
+      error,
+    });
+    throw error;
+  }
+};

--- a/typescript/src/common/index.ts
+++ b/typescript/src/common/index.ts
@@ -5,4 +5,5 @@ export {
   stringifyWWWAuthenticateChallenges,
 } from "./auth";
 export { TOOL_OAUTH_SCOPES_META_KEY, VERSION } from "./const";
+export { executeTool, type ToolObservability } from "./execute";
 export { registerTools, TOOL_REGISTRY_EXCLUSIONS } from "./registry";

--- a/typescript/src/langchain/toolkit.ts
+++ b/typescript/src/langchain/toolkit.ts
@@ -5,7 +5,7 @@ import {
 } from "@langchain/core/tools";
 import SumUp from "@sumup/sdk";
 import type z from "zod";
-import { registerTools } from "../common";
+import { executeTool, registerTools, type ToolObservability } from "../common";
 
 class SumUpAgentToolkit implements BaseToolkit {
   private _sumup: SumUp;
@@ -15,9 +15,11 @@ class SumUpAgentToolkit implements BaseToolkit {
   constructor({
     apiKey,
     host,
+    observability,
   }: {
     apiKey: string;
     host?: string;
+    observability?: ToolObservability;
   }) {
     this._sumup = new SumUp({
       apiKey,
@@ -31,7 +33,7 @@ class SumUpAgentToolkit implements BaseToolkit {
           async (
             input: z.infer<typeof t.parameters>,
           ): Promise<z.infer<typeof t.result>> => {
-            return t.result.parse(await t.callback(this._sumup, input));
+            return await executeTool(t, this._sumup, input, observability);
           },
           {
             name: t.name,

--- a/typescript/src/mcp/toolkit.ts
+++ b/typescript/src/mcp/toolkit.ts
@@ -6,10 +6,12 @@ import SumUp, { APIError } from "@sumup/sdk";
 import { z } from "zod";
 import {
   constructResourceMetadata,
+  executeTool,
   parseWWWAuthenticateChallenges,
   registerTools,
   stringifyWWWAuthenticateChallenges,
   TOOL_OAUTH_SCOPES_META_KEY,
+  type ToolObservability,
   VERSION,
 } from "../common";
 
@@ -18,6 +20,7 @@ export type SumUpAgentToolkitOptions = {
   host?: string;
   resource?: string;
   resourceMetadata?: string;
+  observability?: ToolObservability;
   configuration: ServerOptions;
 };
 
@@ -38,6 +41,7 @@ class SumUpAgentToolkit extends McpServer {
     host,
     resource,
     resourceMetadata,
+    observability,
   }: SumUpAgentToolkitOptions) {
     super(
       {
@@ -125,7 +129,7 @@ class SumUpAgentToolkit extends McpServer {
         ): Promise<CallToolResult> => {
           try {
             const sumup = this.createClient(extra?.authInfo?.token);
-            const result = tool.result.parse(await tool.callback(sumup, args));
+            const result = await executeTool(tool, sumup, args, observability);
             const structuredContent =
               typeof result === "object" && result !== null
                 ? (result as Record<string, unknown>)

--- a/typescript/src/openai/toolkit.ts
+++ b/typescript/src/openai/toolkit.ts
@@ -1,6 +1,6 @@
 import { tool } from "@openai/agents";
 import SumUp from "@sumup/sdk";
-import { registerTools } from "../common";
+import { executeTool, registerTools, type ToolObservability } from "../common";
 import type { ApprovalPolicy } from "../common/types";
 
 type AgentFunctionTool = ReturnType<typeof tool>;
@@ -14,10 +14,12 @@ class SumUpAgentToolkit {
     apiKey,
     host,
     approvalPolicy,
+    observability,
   }: {
     apiKey: string;
     host?: string;
     approvalPolicy?: ApprovalPolicy;
+    observability?: ToolObservability;
   }) {
     this._sumup = new SumUp({
       apiKey,
@@ -36,8 +38,7 @@ class SumUpAgentToolkit {
             ? async (_runContext, input) => await approvalPolicy(t, input)
             : !!t.annotations?.requiresApproval,
           execute: async (input) => {
-            const res = await t.callback(this._sumup, input);
-            return t.result.parse(res);
+            return await executeTool(t, this._sumup, input, observability);
           },
         }),
       );


### PR DESCRIPTION
## What changed

- route AI SDK, LangChain, OpenAI Agents, and MCP calls through one execution seam
- add optional start, end, and error observability callbacks
- report tool name, start time, duration, and original errors
- exclude tool inputs and outputs from lifecycle events
- isolate telemetry failures from tool execution

## Why

Consumers previously had to wrap each adapter independently to observe tool calls, producing inconsistent timing/error data and increasing the risk of logging payment arguments or results.

## Impact

Applications can connect the toolkit to metrics, logs, or OpenTelemetry through one redaction-safe API. A telemetry outage cannot block or alter a tool call.

## Validation

- `npm --prefix typescript run lint`
- `npm --prefix typescript test -- --runInBand`
- TypeScript no-emit check reaches only the three existing default-branch dependency errors; the new execution seam introduces no additional errors
